### PR TITLE
Fixed FID Callback

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -1,3 +1,4 @@
 defaults:
   - is.yaml
+  - fid.yaml
   - _self_


### PR DESCRIPTION
- Earlier FiD callback used CPU to compute metric which is why it was slow. Allowed using `pl_module`'s device.